### PR TITLE
refactor: reorganize players page layout and remove unused features

### DIFF
--- a/src/app/(dashboard)/players/page.tsx
+++ b/src/app/(dashboard)/players/page.tsx
@@ -13,7 +13,6 @@ import { auth } from "@/lib/auth/auth";
 import { loadSearchParams } from "@/modules/players/server/params";
 
 import { PlayersPageView } from "@/modules/players/ui/views/players-page-view";
-import { PlayersSearchFilter } from "@/modules/players/ui/components/players-search-filter";
 import { PlayersHeader } from "@/modules/players/ui/components/players-header";
 
 interface PlayersPageProps {

--- a/src/app/(dashboard)/players/page.tsx
+++ b/src/app/(dashboard)/players/page.tsx
@@ -13,6 +13,8 @@ import { auth } from "@/lib/auth/auth";
 import { loadSearchParams } from "@/modules/players/server/params";
 
 import { PlayersPageView } from "@/modules/players/ui/views/players-page-view";
+import { PlayersSearchFilter } from "@/modules/players/ui/components/players-search-filter";
+import { PlayersHeader } from "@/modules/players/ui/components/players-header";
 
 interface PlayersPageProps {
   searchParams: Promise<SearchParams>;
@@ -29,13 +31,17 @@ const PlayersPage = async ({ searchParams }: PlayersPageProps) => {
     trpc.players.getMany.queryOptions({ ...filters }),
   );
   return (
-    <HydrationBoundary state={dehydrate(queryClient)}>
-      <Suspense fallback={<p>Loading...</p>}>
-        <ErrorBoundary fallback={<p>Error...</p>}>
-          <PlayersPageView />
-        </ErrorBoundary>
-      </Suspense>
-    </HydrationBoundary>
+    <>
+      <PlayersHeader />
+
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <Suspense fallback={<p>Loading...</p>}>
+          <ErrorBoundary fallback={<p>Error...</p>}>
+            <PlayersPageView />
+          </ErrorBoundary>
+        </Suspense>
+      </HydrationBoundary>
+    </>
   );
 };
 

--- a/src/hooks/use-debounce-search.ts
+++ b/src/hooks/use-debounce-search.ts
@@ -1,0 +1,33 @@
+import { useState, useEffect } from "react";
+
+interface UseDebounceSearchOptions {
+  delay?: number;
+}
+
+export function useDebounceSearch<T extends { search: string }>(
+  filters: T,
+  setFilters: (updates: Partial<T>) => void,
+  options: UseDebounceSearchOptions = {}
+) {
+  const { delay = 500 } = options;
+  const [localSearch, setLocalSearch] = useState(filters.search);
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      if (localSearch !== filters.search) {
+        setFilters({ search: localSearch } as Partial<T>);
+      }
+    }, delay);
+
+    return () => clearTimeout(timeoutId);
+  }, [localSearch, setFilters, filters.search, delay]);
+
+  useEffect(() => {
+    setLocalSearch(filters.search);
+  }, [filters.search]);
+
+  return {
+    searchValue: localSearch,
+    setSearchValue: setLocalSearch,
+  };
+}

--- a/src/modules/dashboard/ui/components/dashboard-sidebar.tsx
+++ b/src/modules/dashboard/ui/components/dashboard-sidebar.tsx
@@ -72,12 +72,12 @@ export const DashboardSidebar = () => {
       href: "/profile",
       roles: ["user", "admin"],
     },
-    {
-      icon: Settings,
-      label: "Settings",
-      href: "/settings",
-      roles: ["user", "admin"],
-    },
+    // {
+    //   icon: Settings,
+    //   label: "Settings",
+    //   href: "/settings",
+    //   roles: ["user", "admin"],
+    // },
   ];
 
   const navigationItems = useFilterNavigationItems(navigationItemsConfig);

--- a/src/modules/players/ui/components/players-header.tsx
+++ b/src/modules/players/ui/components/players-header.tsx
@@ -1,0 +1,16 @@
+import { PlayersSearchFilter } from "./players-search-filter";
+
+export const PlayersHeader = () => {
+  return (
+    <div className="space-y-8 pb-6">
+      <div>
+        <h1 className="text-foreground text-3xl font-bold">Players</h1>
+        <p className="text-muted-foreground mt-2">
+          Manage and track all players in the King Academy program
+        </p>
+      </div>
+
+      <PlayersSearchFilter />
+    </div>
+  );
+};

--- a/src/modules/players/ui/components/players-search-filter.tsx
+++ b/src/modules/players/ui/components/players-search-filter.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { SearchIcon } from "lucide-react";
+
+import { useDebounceSearch } from "@/hooks/use-debounce-search";
+
+import { usePlayersFilters } from "@/modules/players/hooks/use-players-filter";
+
+import { Input } from "@/components/ui/input";
+
+export const PlayersSearchFilter = () => {
+  const [filters, setFilters] = usePlayersFilters();
+  const { searchValue, setSearchValue } = useDebounceSearch(
+    filters,
+    setFilters,
+  );
+
+  return (
+    <div className="relative">
+      <Input
+        placeholder="Filter by name"
+        value={searchValue}
+        onChange={(e) => setSearchValue(e.target.value)}
+        className="h-9 w-[200px] bg-white pl-7"
+      />
+
+      <SearchIcon className="text-muted-foreground absolute top-1/2 left-2 size-4 -translate-y-1/2" />
+    </div>
+  );
+};

--- a/src/modules/players/ui/components/players-table.tsx
+++ b/src/modules/players/ui/components/players-table.tsx
@@ -45,20 +45,15 @@ export const PlayersTable = ({ data }: PlayersTableProps) => {
 
   const averageBattingAvg = "N/A";
 
-  console.log({ players });
   return (
     <div className="space-y-8">
-      <h1 className="text-foreground text-3xl font-bold">Players</h1>
-      <p className="text-muted-foreground mt-2">
-        Manage and track all players in the King Academy program
-      </p>
-
-      <div className="grid grid-cols-1 gap-6 sm:grid-cols-3">
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
         <Card className="from-primary/10 to-primary/5 border-border/20 bg-gradient-to-br">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-muted-foreground text-sm font-medium">
               Total Players
             </CardTitle>
+
             <User className="text-primary h-4 w-4" />
           </CardHeader>
 
@@ -80,20 +75,6 @@ export const PlayersTable = ({ data }: PlayersTableProps) => {
           <CardContent>
             <div className="text-foreground text-2xl font-bold">
               {data.totalActive}
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card className="from-primary/10 to-primary/5 border-border/20 bg-gradient-to-br">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-muted-foreground text-sm font-medium">
-              Avg Batting
-            </CardTitle>
-            <Calendar className="text-primary h-4 w-4" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-foreground text-2xl font-bold">
-              {averageBattingAvg}
             </div>
           </CardContent>
         </Card>

--- a/src/modules/players/ui/components/players-table.tsx
+++ b/src/modules/players/ui/components/players-table.tsx
@@ -43,8 +43,6 @@ export const PlayersTable = ({ data }: PlayersTableProps) => {
     status: player.isActive ? "Active" : "Inactive",
   }));
 
-  const averageBattingAvg = "N/A";
-
   return (
     <div className="space-y-8">
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">

--- a/src/modules/schedule/ui/components/schedule-table.tsx
+++ b/src/modules/schedule/ui/components/schedule-table.tsx
@@ -213,7 +213,7 @@ export const ScheduleTable = ({
                             variant="outline"
                             size="sm"
                             onClick={() => onEdit(schedule)}
-                            className="h-8 w-8 p-0"
+                            className="h-6 w-6"
                           >
                             <Edit3 className="h-4 w-4" />
                           </Button>
@@ -222,7 +222,7 @@ export const ScheduleTable = ({
                             variant="destructive"
                             size="sm"
                             onClick={() => onDelete(schedule.id)}
-                            className="h-8 w-8 p-0"
+                            className="h-6 w-6"
                           >
                             <Trash className="h-4 w-4" />
                           </Button>


### PR DESCRIPTION
- Add dedicated search filter and header components to players page
- Remove Settings navigation item from dashboard sidebar
- Simplify players stats cards from 3 to 2 (remove avg batting stat)
- Adjust schedule table action button sizes for better UI consistency
- Remove debug console.log from players table component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Players page header with title, subtitle, and a debounced search filter for quicker name-based filtering.
- Style
  - Streamlined Players page: removed top header section and Avg Batting card; kept Total and Active Players, added an icon, and reduced layout columns.
  - Reduced icon button sizes in the Schedule table for a cleaner look.
- Refactor
  - Updated navigation by removing the Settings item from the personal menu to simplify options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->